### PR TITLE
Workflow path update

### DIFF
--- a/.github/workflows/guardrail-app-publish.yml
+++ b/.github/workflows/guardrail-app-publish.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           node-version: "22"
           cache: "npm"
+          cache-dependency-path: "guardrail-app/package-lock.json"
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Install dependencies


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/guardrail-app-publish.yml` file. The change adds a `cache-dependency-path` parameter to the Node.js setup step, specifying the path to `guardrail-app/package-lock.json` for caching dependencies.