### PR TITLE
Vite command update

### DIFF
--- a/guardrail-app/package.json
+++ b/guardrail-app/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite --port 3000",
-    "build": "tsc -b && vite build",
+		"start": "vite --port 3000",
+		"build": "vite build && tsc",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
This pull request updates the `package.json` file in the `guardrail-app` project to adjust the build process and add a new script for starting the development server.

Key changes:

* [`guardrail-app/package.json`](diffhunk://#diff-8dfe39bfde6c83d90bd4d3539e116c3b020e2c77446ffe72e1a8e0409e423a79L8-R9): Reordered the build steps in the `build` script to run `vite build` before `tsc`, ensuring the TypeScript compilation occurs after the Vite build process. Added a new `start` script to launch the development server on port 3000.