### PR TITLE
Repo base path

### DIFF
--- a/guardrail-app/vite.config.ts
+++ b/guardrail-app/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/guardrail/',
+  base: process.env.VITE_BASE_URL || '/guardrail/',
   server: {
     cors: {
       origin: '*',

--- a/guardrail-app/vite.config.ts
+++ b/guardrail-app/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/guardrail/',
   server: {
     cors: {
       origin: '*',


### PR DESCRIPTION
This pull request makes a small change to the `guardrail-app/vite.config.ts` file. It sets the base URL for the application to `/guardrail/`, ensuring proper routing and asset resolution in the deployed environment.