### PR TITLE
New Deployment and Disable Flow updated

### DIFF
--- a/guardrail-app/src/App.tsx
+++ b/guardrail-app/src/App.tsx
@@ -7,7 +7,7 @@ import { ethers } from 'ethers';
 import Button from '@mui/material/Button';
 import { Alert, Checkbox, FormControlLabel, FormGroup, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField } from '@mui/material'
 
-const GUARDRAIL_ADDRESS = ethers.getAddress(`0x242d70d3DdE2FC64b57457161F5188b2246019F8`) // Sepolia address of the App Guardrail contract
+const GUARDRAIL_ADDRESS = ethers.getAddress(`0xe809d81ac67b3629a5dab4e0293f64537353f40d`) // Sepolia address of the App Guardrail contract
 const GUARD_STORAGE_SLOT = `0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8` // Storage slot for the Tx Guard in the Safe contract
 // const MODULE_GUARD_STORAGE_SLOT = `0xb104e0b93118902c651344349b610029d694cfdec91c589c91ebafbcd0289947` // Storage slot for the Module Guard in the Safe contract
 
@@ -97,7 +97,7 @@ function App() {
       // Check if the Tx Guard removal is already set
       const result = await call(sdk, GUARDRAIL_ADDRESS, "removalSchedule", [ethers.getAddress(safe.safeAddress)])
       if (result > 0n) {
-        setRemovalTimestamp(result)
+        setRemovalTimestamp(result * 1000n) // Convert to milliseconds
       }
     } catch (error) {
       setErrorMessage('Failed to fetch guard removal info with error: ' + error)
@@ -294,9 +294,18 @@ function App() {
                     </div>
                   ) : (
                     <div className="card">
-                      <Button variant="contained" color="error" onClick={() => activateGuardrail(false)} disabled={loading}>
-                        {loading ? 'Submitting transaction...' : 'Disable Guardrail'}
-                      </Button>
+                      {removalTimestamp > 0n && removalTimestamp < BigInt(Date.now()) ? (
+                        <Button variant="contained" color="error" onClick={() => activateGuardrail(false)} disabled={loading}>
+                          {loading ? 'Submitting transaction...' : 'Deactivate Guardrail'}
+                        </Button>
+                      ) : (
+                        <>
+                          <Alert severity="info" style={{margin:'1em'}}>Guardrail Removal Scheduled for {new Date(Number(removalTimestamp)).toLocaleString()}</Alert>
+                          <Button variant="contained" color="error" style={{color:'grey',border:'1px solid',borderColor:'grey'}} disabled>
+                            {'Deactivate Guardrail'}
+                          </Button>                        
+                        </>
+                      )}
                     </div>
                   )
                 :

--- a/script/AppGuardrail.s.sol
+++ b/script/AppGuardrail.s.sol
@@ -12,7 +12,7 @@ contract AppGuardrailScript is Script {
     function run() public {
         vm.startBroadcast(vm.envUint("PRIVATE_KEY"));
 
-        uint256 delay = 0;
+        uint256 delay = 180;
         appGuardrail = new AppGuardrail(delay);
 
         vm.stopBroadcast();

--- a/src/Guardrail.sol
+++ b/src/Guardrail.sol
@@ -196,7 +196,7 @@ contract Guardrail is ITransactionGuard, IModuleGuard, MultiSendCallOnlyv2 {
      *      This will allow the delegate call if the {to} is the guard contract itself (for MultiSendCallOnly functionality)
      */
     function _checkOperationAndAllowance(address safe, address to, bytes4 selector, Enum.Operation operation)
-        internal
+        internal virtual
     {
         if (
             to == address(this)

--- a/src/test/AppGuardrail.sol
+++ b/src/test/AppGuardrail.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity =0.8.28;
 
-import {Guardrail} from "../Guardrail.sol";
+import {Guardrail, Enum, MultiSendCallOnly, MultiSendCallOnlyv2} from "../Guardrail.sol";
 import {SafeInterface} from "../interfaces/SafeInterface.sol";
 import {ITransactionGuard} from "safe-smart-account/contracts/base/GuardManager.sol";
 import {IModuleGuard} from "safe-smart-account/contracts/base/ModuleManager.sol";
@@ -16,6 +16,43 @@ contract AppGuardrail is Guardrail {
      * @param delay The delay for the guard removal and delegate allowance
      */
     constructor(uint256 delay) Guardrail(delay) {}
+
+    /**
+     * @notice Function to check if the delegate is allowed if the operation is delegate call
+     * @param safe The address of the safe
+     * @param to The address of the delegate
+     * @param operation The operation to check
+     * @dev This will revert if the operation is delegate call, but the {to} is not a allowed delegate. This will also
+     *      remove the delegate allowance if the one time allowance is set
+     *      This will allow the delegate call if the {to} is the guard contract itself (for MultiSendCallOnly functionality)
+     *      This will also remove from the delegates list if it is a one time allowance.
+     */
+    function _checkOperationAndAllowance(address safe, address to, bytes4 selector, Enum.Operation operation)
+        internal override
+    {
+        if (
+            to == address(this)
+                && (
+                    selector == MultiSendCallOnly.multiSend.selector
+                        || selector == MultiSendCallOnlyv2.multiSendNoValue.selector
+                )
+        ) {
+            return;
+        }
+
+        if (operation == Enum.Operation.DelegateCall) {
+            Allowance memory allowance = delegatedAllowance[safe][to];
+            require(
+                allowance.allowedTimestamp > 0 && allowance.allowedTimestamp < block.timestamp,
+                DelegateCallNotAllowed(to)
+            );
+
+            if (allowance.oneTimeAllowance) {
+                delete delegatedAllowance[safe][to];
+                delegates[safe].remove(to);
+            }
+        }
+    }
 
     /**
      * @notice This function is called after the execution of a transaction to check if the guard is set up correctly.


### PR DESCRIPTION
## TLDR
- New deployment of the AppGuardrail contract (contains removal of delegates from the set)
- Update to the disable flow in the Safe App
- Delay of 3 mins added for demo purposes

## LLM Description
This pull request makes several updates to the `guardrail-app` and associated smart contracts to improve functionality, enhance clarity, and add new features. The key changes include updating the guardrail contract address, enhancing timestamp handling, improving user interface behavior for guardrail removal, introducing a delay in the guardrail deployment script, and refining delegate call checks in the smart contract.

### Updates to `guardrail-app`:

* **Guardrail Contract Address Update**: Updated the `GUARDRAIL_ADDRESS` constant in `guardrail-app/src/App.tsx` to use a new Sepolia address for the App Guardrail contract.
* **Timestamp Conversion**: Modified the `setRemovalTimestamp` function to convert the removal timestamp from seconds to milliseconds for compatibility with JavaScript's `Date` object.
* **UI Behavior for Guardrail Removal**: Enhanced the user interface to display an informational alert when guardrail removal is scheduled but not yet active, and disabled the "Deactivate Guardrail" button in such cases.

### Updates to smart contracts:

* **Deployment Delay**: Added a 180-second delay to the guardrail deployment in the `run` function of `script/AppGuardrail.s.sol`.
* **Delegate Call Checks**: Refactored `_checkOperationAndAllowance` in `src/Guardrail.sol` to be `virtual` for overriding and added a detailed implementation in `src/test/AppGuardrail.sol` to handle delegate call allowances and one-time delegate removal. [[1]](diffhunk://#diff-14721534964810da5a04ceab21acfdd984a2fbb0e37828ce58d231a49906384aL199-R199) [[2]](diffhunk://#diff-d0a52cc65118303b8bd4cda65133206fbc847b1e2c8f0f67a59a9f986a8c8c73R20-R56)

### Miscellaneous:

* **Imports Update**: Expanded imports in `src/test/AppGuardrail.sol` to include `Enum`, `MultiSendCallOnly`, and `MultiSendCallOnlyv2` for added functionality.