### PR TITLE
Adding `MultiSendCallOnly` during setup

### DIFF
--- a/guardrail-app/src/App.tsx
+++ b/guardrail-app/src/App.tsx
@@ -19,7 +19,7 @@ import {
   TableRow,
   TextField,
 } from '@mui/material'
-import { CONTRACT_INTERFACE_ABI, GUARD_STORAGE_SLOT, GUARDRAIL_ADDRESS, MILLISECONDS_IN_SECOND } from './constants'
+import { CONTRACT_INTERFACE_ABI, GUARD_STORAGE_SLOT, GUARDRAIL_ADDRESS, MILLISECONDS_IN_SECOND, MULTISEND_CALL_ONLY } from './constants'
 import type { ImmediateDelegateAllowanceFormData, ScheduleDelegateAllowanceFormData } from './types'
 
 const CONTRACT_INTERFACE = new ethers.Interface(CONTRACT_INTERFACE_ABI)
@@ -219,8 +219,17 @@ function App() {
       setLoading(true)
       setErrorMessage(null)
       const guardAddress = activate ? GUARDRAIL_ADDRESS : ethers.ZeroAddress
+      const immediateMultiSendCallOnlyAllowance = {
+        to: GUARDRAIL_ADDRESS,
+        value: '0',
+        data: CONTRACT_INTERFACE.encodeFunctionData(
+          'immediateDelegateAllowance',
+          [ethers.getAddress(MULTISEND_CALL_ONLY), false],
+        ),
+      }
       try {
         const txs: BaseTransaction[] = [
+          ...(activate ? [immediateMultiSendCallOnlyAllowance] : []),
           {
             to: safe.safeAddress,
             value: '0',

--- a/guardrail-app/src/constants.ts
+++ b/guardrail-app/src/constants.ts
@@ -1,7 +1,8 @@
 import { ethers } from 'ethers';
 
 // Configuration constants for the Guardrail app
-export const GUARDRAIL_ADDRESS = ethers.getAddress('0xe809d81ac67b3629a5dab4e0293f64537353f40d'); // Sepolia  
+export const GUARDRAIL_ADDRESS = ethers.getAddress('0xe809d81ac67b3629a5dab4e0293f64537353f40d'); // Sepolia
+export const MULTISEND_CALL_ONLY = ethers.getAddress('0x9641d764fc13c8B624c04430C7356C1C7C8102e2'); // Sepolia
 
 // Storage slots for Safe contract
 export const GUARD_STORAGE_SLOT = '0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8' as const


### PR DESCRIPTION
## TLDR
- Added immediate delegate allowance for `MultiSendCallOnly` at the time of guard setup.

## LLM Description
This pull request introduces a new constant, `MULTISEND_CALL_ONLY`, to the Guardrail app and integrates it into the transaction logic for activating guardrails. The changes primarily focus on enhancing the functionality of the `App` component by adding a new transaction when guardrails are activated.

### New Constant Addition:
* [`guardrail-app/src/constants.ts`](diffhunk://#diff-c90788347f588244720a3dd7c1d303bef9d97c4f4ed76439d79c49288b7a0f3eR5): Added `MULTISEND_CALL_ONLY` as a new constant, representing an address used in the Guardrail app.

### Updates to the `App` Component:
* [`guardrail-app/src/App.tsx`](diffhunk://#diff-fd339760efc333a5e935af2f83e321b0e7cdf48203ed1fe7b4620e7aab49ef64L22-R22): Imported the `MULTISEND_CALL_ONLY` constant for use in the file.
* [`guardrail-app/src/App.tsx`](diffhunk://#diff-fd339760efc333a5e935af2f83e321b0e7cdf48203ed1fe7b4620e7aab49ef64R222-R232): Updated the `App` component to include a new transaction, `immediateMultiSendCallOnlyAllowance`, in the transaction list when activating guardrails. This transaction encodes a call to the `immediateDelegateAllowance` function with the `MULTISEND_CALL_ONLY` address.