### PR TITLE
Banner & Footer Component

### DIFF
--- a/guardrail-app/src/App.tsx
+++ b/guardrail-app/src/App.tsx
@@ -21,6 +21,7 @@ import {
 } from '@mui/material'
 import { CONTRACT_INTERFACE_ABI, GUARD_STORAGE_SLOT, GUARDRAIL_ADDRESS, MILLISECONDS_IN_SECOND, MULTISEND_CALL_ONLY } from './constants'
 import type { ImmediateDelegateAllowanceFormData, ScheduleDelegateAllowanceFormData } from './types'
+import { SafeResearchBanner, SafeResearchFooter } from './components/SafeResearch'
 
 const CONTRACT_INTERFACE = new ethers.Interface(CONTRACT_INTERFACE_ABI)
 
@@ -334,9 +335,7 @@ function App() {
 
   return (
     <>
-      <div className="card">
-        <Alert severity="warning">This demo is an experimental beta release. Code is not audited. Use at your own risk.</Alert>
-      </div>
+      <SafeResearchBanner />
       <div>
         <a href="https://github.com/safe-research/guardrail" target="_blank">
           <img
@@ -657,6 +656,7 @@ function App() {
         )}
         {errorMessage ? <p className="error">{errorMessage}</p> : null}
       </div>
+      <SafeResearchFooter repo='guardrail' />
     </>
   )
 }

--- a/guardrail-app/src/components/SafeResearch.tsx
+++ b/guardrail-app/src/components/SafeResearch.tsx
@@ -1,0 +1,46 @@
+import { Alert, Link, Typography } from '@mui/material'
+import type { ReactNode } from 'react'
+
+export const CustomLink = ({
+  to,
+  children,
+}: {
+  to: string
+  children: ReactNode
+}) => {
+  return (
+    <Link
+      href={to}
+      target="_blank"
+      rel="noopener"
+      underline="none"
+      color="inherit"
+      sx={{ ':hover': { color: '#12ff80' } }}
+    >
+      {children}
+    </Link>
+  )
+}
+
+export const SafeResearchBanner = () => {
+  return (
+    <Alert severity="warning">
+      This demo is an experimental beta release. Code is not audited. Use at
+      your own risk.
+    </Alert>
+  )
+}
+
+export const SafeResearchFooter = ({ repo }: { repo: string }) => {
+  return (
+    <Typography>
+      <CustomLink to="https://github.com/safe-research">
+        Built by Safe Research
+      </CustomLink>
+      &nbsp;&hearts;&nbsp;
+      <CustomLink to={`https://github.com/safe-research/${repo}`}>
+        Source on GitHub
+      </CustomLink>
+    </Typography>
+  )
+}


### PR DESCRIPTION
This pull request refactors the way the experimental warning banner and project footer are rendered in the app, moving them into reusable components for better code organization and maintainability. It introduces a new file, `SafeResearch.tsx`, containing these components and updates their usage in `App.tsx`.

**Component extraction and reuse:**

* Added new `SafeResearchBanner` and `SafeResearchFooter` components in `guardrail-app/src/components/SafeResearch.tsx`, encapsulating the experimental warning and footer links.
* Replaced the inline warning banner in `App.tsx` with the new `SafeResearchBanner` component.
* Added the `SafeResearchFooter` component to the bottom of the `App.tsx` render output.

**Code organization:**

* Imported `SafeResearchBanner` and `SafeResearchFooter` into `App.tsx` for use in the main application component.